### PR TITLE
feat: LLM false-positive filter with SQLite verdict cache

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,95 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+# Install dependencies (run from repo root)
+npm install
+
+# Build all packages
+npm run build
+
+# Build a specific workspace
+npm run build --workspace @goshenkata/dryscan-core
+npm run build --workspace @goshenkata/dryscan-cli
+
+# Run all tests
+npm run test
+
+# Run core tests only (Mocha unit tests)
+npm run test --workspace @goshenkata/dryscan-core
+
+# Run CLI tests (unit + bats integration)
+npm run test --workspace @goshenkata/dryscan-cli
+npm run test:unit --workspace @goshenkata/dryscan-cli
+npm run test:bats --workspace @goshenkata/dryscan-cli
+
+# Run a single test file
+tsx node_modules/mocha/bin/mocha "core/test/duplicates.test.mjs"
+
+# Lint
+npm run lint
+
+# Run CLI in dev mode (no build needed)
+npm run dryscan:dev -- <args>
+
+# Run built CLI
+npm run dryscan -- <args>
+```
+
+## Architecture
+
+This is an npm workspaces monorepo with three packages:
+
+- **`core/`** (`@goshenkata/dryscan-core`) — Core library. Contains all analysis logic. Published to npm.
+- **`cli/`** (`@goshenkata/dryscan-cli`) — Commander-based CLI wrapper over core. Published to npm.
+- **`vscode-extension/`** (`@goshenkata/dryscan-vscode-extension`) — VS Code extension using core.
+
+### Analysis Pipeline (core)
+
+1. **`IndexUnitExtractor`** — Walks the repo, delegates to `LanguageExtractor` implementations (currently only `JavaExtractor` via `tree-sitter-java`) to parse source into `IndexUnit` objects (class/function/block).
+
+2. **`DryScanDatabase`** — SQLite via TypeORM. Stores `IndexUnitEntity` and `FileEntity`. Located at `<repo>/.dry/index.db`.
+
+3. **`EmbeddingService`** — Generates vector embeddings per `IndexUnit`. Supports Ollama (URL config) and HuggingFace Inference API (`huggingface` config). Uses `qwen3-embedding:0.6b` model.
+
+4. **`DuplicateService`** — Compares all unit pairs using cosine similarity on cached embeddings (`DuplicationCache`). Applies per-type thresholds (function/block/class). Reuses clean-pair results from the previous report when only some files changed (incremental optimization).
+
+5. **`DryScan`** — Top-level facade. Orchestrates `init` (3-phase: extract → resolve deps → embed), `updateIndex` (incremental), and `buildDuplicateReport`.
+
+### Key Config
+
+`dryconfig.json` at repo root controls analysis:
+- `embeddingSource`: Ollama URL (e.g. `http://localhost:11434`) or `"huggingface"`
+- `threshold`: cosine similarity threshold (0–1, default 0.8)
+- `contextLength`: max chars for embedding (default 2048)
+- `excludedPaths`: glob patterns to skip
+- `excludedPairs`: specific unit pair IDs to ignore
+- `minLines` / `minBlockLines`: minimum unit size
+
+### Data Flow
+
+```
+Source files → IndexUnitExtractor → IndexUnit[]
+                                          ↓
+                               DryScanDatabase (SQLite)
+                                          ↓
+                               EmbeddingService (Ollama/HF)
+                                          ↓
+                               DuplicationCache (in-memory similarity matrix)
+                                          ↓
+                               DuplicateService → DuplicateReport (.dry/reports/)
+```
+
+### Adding a Language
+
+Implement `LanguageExtractor` (in `core/src/extractors/LanguageExtractor.ts`) and add it to `defaultExtractors()` in `IndexUnitExtractor.ts`. The Java extractor (`core/src/extractors/java.ts`) is the reference implementation using `tree-sitter`.
+
+### Debug Logging
+
+Uses the `debug` package. Enable with:
+```bash
+DEBUG=DryScan:* npm run dryscan -- dupes .
+```

--- a/cli/test/dryscan-cli.bats
+++ b/cli/test/dryscan-cli.bats
@@ -51,7 +51,8 @@ embedding_source() {
 write_base_config() {
   cat > dryconfig.json <<EOF
 {
-  "embeddingSource": "$(embedding_source)"
+  "embeddingSource": "$(embedding_source)",
+  "enableLLMFilter": false
 }
 EOF
 }
@@ -596,4 +597,86 @@ EOF
 
   elapsed=$(node -e 'const fs=require("fs"); const d=JSON.parse(fs.readFileSync(process.argv[1],"utf8")); if (typeof d.elapsedMs !== "number") process.exit(1); process.stdout.write(String(d.elapsedMs));' "${out_json}")
   node -e 'const v=Number(process.argv[1]); if (!(v > 0)) process.exit(1);' "${elapsed}"
+}
+
+@test "llm verdict cache is used on second run and is considerably faster" {
+  # Enable LLM filter for this test — requires a running Ollama instance with qwen-duplication-2b
+  cat > dryconfig.json <<EOF
+{
+  "embeddingSource": "$(embedding_source)",
+  "enableLLMFilter": true
+}
+EOF
+
+  run_dryscan init "${TEST_ROOT}"
+  [ "${status}" -eq 0 ]
+
+  # First run: no cached verdicts, LLM classifies every candidate pair
+  first_out="${BATS_TMPDIR}/llm-first-${BATS_TEST_NUMBER}.out"
+  first_start=$(date +%s%N)
+  node "${CLI_BIN}" --debug dupes --json "${TEST_ROOT}" >"${first_out}" 2>/dev/null
+  first_end=$(date +%s%N)
+  [ "$?" -eq 0 ]
+  first_time_ms=$(( (first_end - first_start) / 1000000 ))
+
+  # Verify output is valid JSON with duplicates key
+  [ -s "${first_out}" ]
+  [[ "$(cat "${first_out}")" == *"\"duplicates\""* ]]
+
+  # Verdicts must have been persisted after the first run
+  verdict_count=$(sqlite_query "SELECT COUNT(*) FROM llm_verdicts;")
+  [ "${verdict_count}" -gt 0 ]
+
+  # Second run: no file changes — every candidate pair should be served from cache
+  second_out="${BATS_TMPDIR}/llm-second-${BATS_TEST_NUMBER}.out"
+  second_start=$(date +%s%N)
+  node "${CLI_BIN}" --debug dupes --json "${TEST_ROOT}" >"${second_out}" 2>/dev/null
+  second_end=$(date +%s%N)
+  [ "$?" -eq 0 ]
+  second_time_ms=$(( (second_end - second_start) / 1000000 ))
+
+  # Verdict row count must not grow — no new LLM calls were made
+  verdict_count_after=$(sqlite_query "SELECT COUNT(*) FROM llm_verdicts;")
+  [ "${verdict_count_after}" -eq "${verdict_count}" ]
+
+  # Second run output must be identical (same duplicate set)
+  first_dupes=$(node -e 'const fs=require("fs");const j=JSON.parse(fs.readFileSync(process.argv[1],"utf8"));process.stdout.write(String(j.score.duplicateGroups));' "${first_out}")
+  second_dupes=$(node -e 'const fs=require("fs");const j=JSON.parse(fs.readFileSync(process.argv[1],"utf8"));process.stdout.write(String(j.score.duplicateGroups));' "${second_out}")
+  [ "${first_dupes}" -eq "${second_dupes}" ]
+
+  # Second run must be faster (LLM calls skipped)
+  [ "${second_time_ms}" -lt "${first_time_ms}" ]
+
+  delta_ms=$(( first_time_ms - second_time_ms ))
+  echo "LLM verdict cache: first=${first_time_ms}ms second=${second_time_ms}ms saved=${delta_ms}ms"
+}
+
+@test "llm verdict cache is invalidated for dirty files" {
+  cat > dryconfig.json <<EOF
+{
+  "embeddingSource": "$(embedding_source)",
+  "enableLLMFilter": true
+}
+EOF
+
+  run_dryscan init "${TEST_ROOT}"
+  [ "${status}" -eq 0 ]
+
+  # Populate the cache
+  run_dryscan dupes --json "${TEST_ROOT}"
+  [ "${status}" -eq 0 ]
+
+  initial_verdict_count=$(sqlite_query "SELECT COUNT(*) FROM llm_verdicts;")
+  [ "${initial_verdict_count}" -gt 0 ]
+
+  # Touch a source file to make it dirty
+  touch src/main/java/com/example/demo/service/UserService.java
+
+  # Run again — dirty-file verdicts must be reclassified (fire-and-forget eviction runs)
+  run_dryscan dupes --json "${TEST_ROOT}"
+  [ "${status}" -eq 0 ]
+
+  # After reclassification the cache is repopulated — row count should be >= initial
+  verdict_count_after=$(sqlite_query "SELECT COUNT(*) FROM llm_verdicts;")
+  [ "${verdict_count_after}" -gt 0 ]
 }

--- a/core/src/config/dryconfig.ts
+++ b/core/src/config/dryconfig.ts
@@ -14,6 +14,7 @@ export const DEFAULT_CONFIG: DryConfig = {
   threshold: 0.8,
   embeddingSource: "http://localhost:11434",
   contextLength: 2048,
+  enableLLMFilter: true,
 };
 
 const validator = new Validator();
@@ -28,6 +29,7 @@ const partialConfigSchema: Schema = {
     threshold: { type: "number" },
     embeddingSource: { type: "string" },
     contextLength: { type: "number" },
+    enableLLMFilter: { type: "boolean" },
   },
 };
 
@@ -41,6 +43,7 @@ const fullConfigSchema: Schema = {
     "threshold",
     "embeddingSource",
     "contextLength",
+    "enableLLMFilter",
   ],
 };
 

--- a/core/src/db/DryScanDatabase.ts
+++ b/core/src/db/DryScanDatabase.ts
@@ -5,11 +5,13 @@ import { DataSource, Repository, In } from "typeorm";
 import { FileEntity } from "./entities/FileEntity";
 import { IndexUnit } from "../types";
 import { IndexUnitEntity } from "./entities/IndexUnitEntity";
+import { LLMVerdictEntity } from "./entities/LLMVerdictEntity";
 
 export class DryScanDatabase {
   private dataSource?: DataSource;
   private unitRepository?: Repository<IndexUnitEntity>;
   private fileRepository?: Repository<FileEntity>;
+  private verdictRepository?: Repository<LLMVerdictEntity>;
 
   isInitialized(): boolean {
     return !!this.dataSource?.isInitialized;
@@ -21,7 +23,7 @@ export class DryScanDatabase {
     this.dataSource = new DataSource({
       type: "sqlite",
       database: dbPath,
-      entities: [IndexUnitEntity, FileEntity],
+      entities: [IndexUnitEntity, FileEntity, LLMVerdictEntity],
       synchronize: true,
       logging: false,
     });
@@ -29,6 +31,7 @@ export class DryScanDatabase {
     await this.dataSource.initialize();
     this.unitRepository = this.dataSource.getRepository(IndexUnitEntity);
     this.fileRepository = this.dataSource.getRepository(FileEntity);
+    this.verdictRepository = this.dataSource.getRepository(LLMVerdictEntity);
   }
 
   async saveUnit(unit: IndexUnit): Promise<void> {
@@ -123,6 +126,40 @@ export class DryScanDatabase {
   async removeFilesByFilePaths(filePaths: string[]): Promise<void> {
     if (!this.fileRepository) throw new Error("Database not initialized");
     await this.fileRepository.delete({ filePath: In(filePaths) });
+  }
+
+  // ── LLM verdict cache ──────────────────────────────────────────────────────
+
+  /**
+   * Retrieves cached LLM verdicts for the given pair keys.
+   */
+  async getLLMVerdicts(pairKeys: string[]): Promise<LLMVerdictEntity[]> {
+    if (!this.verdictRepository) throw new Error("Database not initialized");
+    if (pairKeys.length === 0) return [];
+    return this.verdictRepository.find({ where: { pairKey: In(pairKeys) } });
+  }
+
+  /**
+   * Upserts LLM verdicts for a batch of pairs.
+   */
+  async saveLLMVerdicts(verdicts: LLMVerdictEntity[]): Promise<void> {
+    if (!this.verdictRepository) throw new Error("Database not initialized");
+    if (verdicts.length === 0) return;
+    await this.verdictRepository.save(verdicts);
+  }
+
+  /**
+   * Removes all cached LLM verdicts where either side's file path matches.
+   * Used to evict stale verdicts when files become dirty.
+   */
+  async removeLLMVerdictsByFilePaths(filePaths: string[]): Promise<void> {
+    if (!this.dataSource?.isInitialized) throw new Error("Database not initialized");
+    if (filePaths.length === 0) return;
+    const placeholders = filePaths.map(() => "?").join(", ");
+    await this.dataSource.query(
+      `DELETE FROM llm_verdicts WHERE leftFilePath IN (${placeholders}) OR rightFilePath IN (${placeholders})`,
+      [...filePaths, ...filePaths]
+    );
   }
 
   async close(): Promise<void> {

--- a/core/src/db/entities/LLMVerdictEntity.ts
+++ b/core/src/db/entities/LLMVerdictEntity.ts
@@ -1,0 +1,28 @@
+import { Entity, PrimaryColumn, Column } from "typeorm";
+
+/**
+ * Persisted LLM classification verdict for a duplicate candidate pair.
+ * Used to skip re-classification on subsequent runs when neither file has changed.
+ */
+@Entity("llm_verdicts")
+export class LLMVerdictEntity {
+  /** Stable, order-independent key: sorted(left.id, right.id).join("::") */
+  @PrimaryColumn("text")
+  pairKey!: string;
+
+  /** "yes" = confirmed duplicate, "no" = false positive */
+  @Column("text")
+  verdict!: "yes" | "no";
+
+  /** File path of the left unit — used to invalidate when the file becomes dirty */
+  @Column("text")
+  leftFilePath!: string;
+
+  /** File path of the right unit — used to invalidate when the file becomes dirty */
+  @Column("text")
+  rightFilePath!: string;
+
+  /** Unix timestamp (ms) when the verdict was recorded */
+  @Column("integer")
+  createdAt!: number;
+}

--- a/core/src/services/DuplicateService.ts
+++ b/core/src/services/DuplicateService.ts
@@ -5,6 +5,7 @@ import { DuplicateAnalysisResult, DuplicateGroup, DuplicateReport, DuplicationSc
 import { indexConfig } from "../config/indexConfig";
 import { DryConfig } from "../types";
 import { DuplicationCache } from "./DuplicationCache";
+import { LLMFalsePositiveDetector } from "./LLMFalsePositiveDetector";
 
 const log = debug("DryScan:DuplicateService");
 
@@ -57,6 +58,27 @@ export class DuplicateService {
       merged.length - filtered.length,
       reusableClean.length
     );
+
+    // LLM false-positive filter (opt-in, default ON via enableLLMFilter config)
+    if (config.enableLLMFilter) {
+      // Fire-and-forget: evict stale LLM verdicts for files that just changed.
+      // The detector's dirtySet check guarantees correctness; this is DB hygiene.
+      if (dirtyPaths.length > 0) {
+        void this.deps.db.removeLLMVerdictsByFilePaths(dirtyPaths).catch((err) => {
+          log("Failed to evict stale LLM verdicts: %s", (err as Error).message);
+        });
+      }
+      const detector = new LLMFalsePositiveDetector(this.deps.repoPath, this.deps.db);
+      const decision = await detector.classify(filtered, dirtyPaths);
+      log(
+        "LLM filter: %d true positives, %d false positives",
+        decision.truePositives.length,
+        decision.falsePositives.length
+      );
+      const score = this.computeDuplicationScore(decision.truePositives, allUnits);
+      log("findDuplicates completed in %dms", (performance.now() - t0).toFixed(2));
+      return { duplicates: decision.truePositives, score };
+    }
 
     const score = this.computeDuplicationScore(filtered, allUnits);
     log("findDuplicates completed in %dms", (performance.now() - t0).toFixed(2));

--- a/core/src/services/LLMFalsePositiveDetector.ts
+++ b/core/src/services/LLMFalsePositiveDetector.ts
@@ -1,0 +1,237 @@
+import fs from "fs/promises";
+import path from "path";
+import debug from "debug";
+import { DuplicateGroup, LLMDecision } from "../types";
+import { DryScanDatabase } from "../db/DryScanDatabase";
+import { LLMVerdictEntity } from "../db/entities/LLMVerdictEntity";
+import { configStore } from "../config/configStore";
+
+const log = debug("DryScan:LLMFalsePositiveDetector");
+
+/**
+ * Fine-tuned model used for false-positive classification.
+ * Must be loaded in Ollama with the Qwen3-instruct chat template (see TRAINING_FORMAT.md).
+ */
+const LLM_MODEL = "qwen-duplication-2b:latest";
+
+/**
+ * Maximum number of LLM classification requests dispatched in parallel per batch.
+ */
+const CONCURRENCY_LIMIT = 20;
+
+/**
+ * Classifies embedding-confirmed duplicate candidates via a fine-tuned LLM
+ * (qwen-duplication-2b) to separate true duplicates from false positives.
+ *
+ * Verdicts are persisted in the `llm_verdicts` table and reused on subsequent
+ * runs as long as neither file in the pair has changed (dirty-path invalidation
+ * is handled by the caller before invoking `classify`).
+ *
+ * NOTE: Language detection is hardcoded to Java until additional LanguageExtractor
+ * implementations are added to the pipeline.
+ */
+export class LLMFalsePositiveDetector {
+  constructor(
+    private readonly repoPath: string,
+    private readonly db: DryScanDatabase
+  ) {}
+
+  /**
+   * Classifies `candidates` as true positives or false positives.
+   *
+   * Cache behaviour:
+   * - Pairs where NEITHER file is in `dirtyPaths` and a cached verdict exists → reuse.
+   * - All other pairs → call the LLM and persist the new verdict.
+   */
+  async classify(candidates: DuplicateGroup[], dirtyPaths: string[]): Promise<LLMDecision> {
+    if (candidates.length === 0) {
+      return { truePositives: [], falsePositives: [] };
+    }
+
+    const dirtySet = new Set(dirtyPaths);
+    const pairKeys = candidates.map((g) => this.pairKey(g));
+
+    const cached = await this.db.getLLMVerdicts(pairKeys);
+    const verdictMap = new Map(cached.map((v) => [v.pairKey, v.verdict]));
+
+    const toClassify = candidates.filter((g) => {
+      if (dirtySet.has(g.left.filePath) || dirtySet.has(g.right.filePath)) return true;
+      return !verdictMap.has(this.pairKey(g));
+    });
+
+    log(
+      "%d candidates: %d from cache, %d need classification",
+      candidates.length,
+      candidates.length - toClassify.length,
+      toClassify.length
+    );
+
+    if (toClassify.length > 0) {
+      const newVerdicts = await this.classifyWithConcurrency(toClassify);
+      const entities: LLMVerdictEntity[] = newVerdicts.map(({ group, verdict }) =>
+        Object.assign(new LLMVerdictEntity(), {
+          pairKey: this.pairKey(group),
+          verdict,
+          leftFilePath: group.left.filePath,
+          rightFilePath: group.right.filePath,
+          createdAt: Date.now(),
+        })
+      );
+      await this.db.saveLLMVerdicts(entities);
+      for (const { group, verdict } of newVerdicts) {
+        verdictMap.set(this.pairKey(group), verdict);
+      }
+    }
+
+    const truePositives: DuplicateGroup[] = [];
+    const falsePositives: DuplicateGroup[] = [];
+
+    for (const group of candidates) {
+      if (verdictMap.get(this.pairKey(group)) === "no") {
+        falsePositives.push(group);
+      } else {
+        // "yes", unknown, or error fallback → keep as true positive
+        truePositives.push(group);
+      }
+    }
+
+    log("%d true positives, %d false positives", truePositives.length, falsePositives.length);
+    return { truePositives, falsePositives };
+  }
+
+  /** Stable, order-independent pair key matching DuplicateService.groupKey. */
+  pairKey(group: DuplicateGroup): string {
+    return [group.left.id, group.right.id].sort().join("::");
+  }
+
+  private async classifyWithConcurrency(
+    groups: DuplicateGroup[]
+  ): Promise<Array<{ group: DuplicateGroup; verdict: "yes" | "no" }>> {
+    const results: Array<{ group: DuplicateGroup; verdict: "yes" | "no" }> = [];
+    for (let i = 0; i < groups.length; i += CONCURRENCY_LIMIT) {
+      const batch = groups.slice(i, i + CONCURRENCY_LIMIT);
+      const batchResults = await Promise.all(batch.map((g) => this.classifyPair(g)));
+      results.push(...batchResults);
+    }
+    return results;
+  }
+
+  private async classifyPair(
+    group: DuplicateGroup
+  ): Promise<{ group: DuplicateGroup; verdict: "yes" | "no" }> {
+    try {
+      const config = await configStore.get(this.repoPath);
+      const ollamaBaseUrl = this.resolveOllamaBaseUrl(config.embeddingSource);
+      const prompt = await this.buildPrompt(group);
+
+      const response = await fetch(`${ollamaBaseUrl}/api/chat`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          model: LLM_MODEL,
+          messages: [{ role: "user", content: prompt }],
+          stream: false,
+          options: { temperature: 0, num_predict: 32 },
+        }),
+      });
+
+      if (!response.ok) {
+        log("LLM request failed for pair %s: HTTP %d — defaulting to true positive", this.pairKey(group), response.status);
+        return { group, verdict: "yes" };
+      }
+
+      const data = (await response.json()) as { message?: { content?: string } };
+      const raw = data.message?.content?.trim().toLowerCase() ?? "";
+      const verdict: "yes" | "no" = raw.startsWith("yes") ? "yes" : "no";
+      log("Pair %s → %s (raw: %s)", this.pairKey(group), verdict, raw);
+      return { group, verdict };
+    } catch (err) {
+      log("LLM classification error for pair %s: %s — defaulting to true positive", this.pairKey(group), (err as Error).message);
+      return { group, verdict: "yes" };
+    }
+  }
+
+  /**
+   * Extracts the Ollama base URL from the configured embeddingSource.
+   * Falls back to http://localhost:11434 for non-URL values (e.g. "ollama", "huggingface").
+   */
+  private resolveOllamaBaseUrl(embeddingSource: string): string {
+    if (/^https?:\/\//i.test(embeddingSource)) {
+      const url = new URL(embeddingSource);
+      return `${url.protocol}//${url.host}`;
+    }
+    return "http://localhost:11434";
+  }
+
+  /**
+   * Builds the inference prompt matching the training format documented in
+   * DryScanDiplomna/finetune/TRAINING_FORMAT.md.
+   *
+   * TODO: detect language from file extension once more LanguageExtractors are added.
+   *       Currently hardcoded to "java".
+   */
+  private async buildPrompt(group: DuplicateGroup): Promise<string> {
+    const projectName = path.basename(this.repoPath);
+    // Language is hardcoded to java — the only extractor currently implemented.
+    const lang = "java";
+
+    const [fileAContent, fileBContent] = await Promise.all([
+      fs.readFile(path.join(this.repoPath, group.left.filePath), "utf8").catch(() => ""),
+      fs.readFile(path.join(this.repoPath, group.right.filePath), "utf8").catch(() => ""),
+    ]);
+
+    const lines = [
+      "You are a strict code-duplication judge.",
+      "",
+      "Task:",
+      "Decide if Snippet A and Snippet B count as duplicated code.",
+      "Answer based on BOTH the snippets and their full-file context.",
+      "",
+      "Definition (return 'yes' if ANY apply):",
+      "- Straight/near clone (small edits, renames, reformatting).",
+      "- Semantic duplicate: different syntax but same behavior/intent.",
+      "- Extractable duplicate: not identical, but a reasonable shared helper/abstraction could be extracted.",
+      "Return 'no' ONLY if they clearly implement different responsibilities/logic and are not reasonably extractable.",
+      "",
+      "Output rules (mandatory):",
+      "- Output EXACTLY one token: yes OR no",
+      "- No punctuation, no extra words, no explanations",
+      "- Think silently before answering",
+      "",
+      "Evidence:",
+      "",
+      `=== Snippet A (project=${projectName} id=${group.left.id}) ===`,
+      `name: ${group.left.name}`,
+      `unitType: ${group.left.unitType}`,
+      `filePath: ${group.left.filePath}`,
+      `lines: ${group.left.startLine}-${group.left.endLine}`,
+      "```" + lang,
+      group.left.code,
+      "```",
+      "",
+      `=== Snippet B (project=${projectName} id=${group.right.id}) ===`,
+      `name: ${group.right.name}`,
+      `unitType: ${group.right.unitType}`,
+      `filePath: ${group.right.filePath}`,
+      `lines: ${group.right.startLine}-${group.right.endLine}`,
+      "```" + lang,
+      group.right.code,
+      "```",
+      "",
+      `=== Full file A: ${group.left.filePath} ===`,
+      "```" + lang,
+      fileAContent,
+      "```",
+      "",
+      `=== Full file B: ${group.right.filePath} ===`,
+      "```" + lang,
+      fileBContent,
+      "```",
+      "",
+      "Question: Are Snippet A and Snippet B duplicated code under the definition above?",
+      "Answer:",
+    ];
+
+    return lines.join("\n");
+  }
+}

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -53,6 +53,13 @@ export interface DryConfig {
   threshold: number;
   embeddingSource: string;
   contextLength: number;
+  /** When true, confirmed duplicate candidates are sent to the fine-tuned LLM for false-positive filtering. Default: true. */
+  enableLLMFilter: boolean;
+}
+
+export interface LLMDecision {
+  truePositives: DuplicateGroup[];
+  falsePositives: DuplicateGroup[];
 }
 
 export interface IndexUnit {

--- a/core/test/LLMFalsePositiveDetector.test.mjs
+++ b/core/test/LLMFalsePositiveDetector.test.mjs
@@ -1,0 +1,267 @@
+import { expect } from "chai";
+import sinon from "sinon";
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+import { LLMFalsePositiveDetector } from "../src/services/LLMFalsePositiveDetector.ts";
+import { configStore } from "../src/config/configStore.ts";
+import { IndexUnitType } from "../src/types.ts";
+
+// ── helpers ────────────────────────────────────────────────────────────────
+
+function makeGroup(leftId, rightId, leftFile = "A.java", rightFile = "B.java") {
+  return {
+    id: `${leftId}::${rightId}`,
+    similarity: 0.92,
+    shortId: "short1",
+    exclusionString: "FUNCTION|fn1|fn2",
+    left: {
+      id: leftId,
+      name: "fn1",
+      filePath: leftFile,
+      startLine: 1,
+      endLine: 10,
+      code: "void fn1() { return 1; }",
+      unitType: IndexUnitType.FUNCTION,
+    },
+    right: {
+      id: rightId,
+      name: "fn2",
+      filePath: rightFile,
+      startLine: 20,
+      endLine: 30,
+      code: "void fn2() { return 1; }",
+      unitType: IndexUnitType.FUNCTION,
+    },
+  };
+}
+
+function mockFetch(answer) {
+  return sinon.stub(globalThis, "fetch").resolves({
+    ok: true,
+    json: async () => ({ message: { content: answer } }),
+  });
+}
+
+function makeMockDb(cachedVerdicts = []) {
+  return {
+    getLLMVerdicts: sinon.stub().resolves(cachedVerdicts),
+    saveLLMVerdicts: sinon.stub().resolves(),
+    removeLLMVerdictsByFilePaths: sinon.stub().resolves(),
+  };
+}
+
+// ── suite ──────────────────────────────────────────────────────────────────
+
+describe("LLMFalsePositiveDetector", function () {
+  this.timeout(8000);
+
+  let testDir;
+  let detector;
+  let mockDb;
+
+  beforeEach(async () => {
+    sinon.restore();
+
+    testDir = await fs.mkdtemp(path.join(os.tmpdir(), "dryscan-llm-test-"));
+
+    // Stub configStore so detector doesn't need a real dryconfig.json
+    sinon.stub(configStore, "get").resolves({
+      embeddingSource: "http://localhost:11434",
+      enableLLMFilter: true,
+    });
+
+    // Stub fs.readFile so prompt building doesn't hit disk
+    sinon.stub(fs, "readFile").resolves("class Stub {}");
+
+    mockDb = makeMockDb();
+    detector = new LLMFalsePositiveDetector(testDir, mockDb);
+  });
+
+  afterEach(async () => {
+    sinon.restore();
+    await fs.rm(testDir, { recursive: true, force: true });
+  });
+
+  // ── classify: empty input ────────────────────────────────────────────────
+
+  it("returns empty arrays when candidates list is empty", async () => {
+    const result = await detector.classify([], []);
+    expect(result.truePositives).to.be.an("array").that.is.empty;
+    expect(result.falsePositives).to.be.an("array").that.is.empty;
+  });
+
+  // ── classify: LLM verdicts ───────────────────────────────────────────────
+
+  it("classifies pair as true positive when LLM responds 'yes'", async () => {
+    mockFetch("yes");
+    const group = makeGroup("u1", "u2");
+    const { truePositives, falsePositives } = await detector.classify([group], []);
+    expect(truePositives).to.have.length(1);
+    expect(falsePositives).to.have.length(0);
+  });
+
+  it("classifies pair as false positive when LLM responds 'no'", async () => {
+    mockFetch("no");
+    const group = makeGroup("u1", "u2");
+    const { truePositives, falsePositives } = await detector.classify([group], []);
+    expect(truePositives).to.have.length(0);
+    expect(falsePositives).to.have.length(1);
+  });
+
+  it("is case-insensitive: 'YES' → true positive, 'NO' → false positive", async () => {
+    const fetchStub = sinon.stub(globalThis, "fetch");
+    fetchStub.onFirstCall().resolves({ ok: true, json: async () => ({ message: { content: "YES" } }) });
+    fetchStub.onSecondCall().resolves({ ok: true, json: async () => ({ message: { content: "NO" } }) });
+
+    const groups = [makeGroup("a1", "a2", "A.java", "B.java"), makeGroup("b1", "b2", "C.java", "D.java")];
+    const { truePositives, falsePositives } = await detector.classify(groups, []);
+    expect(truePositives).to.have.length(1);
+    expect(falsePositives).to.have.length(1);
+  });
+
+  it("defaults to true positive (keep) when LLM HTTP call fails", async () => {
+    sinon.stub(globalThis, "fetch").rejects(new Error("connection refused"));
+    const group = makeGroup("u1", "u2");
+    const { truePositives, falsePositives } = await detector.classify([group], []);
+    expect(truePositives).to.have.length(1);
+    expect(falsePositives).to.have.length(0);
+  });
+
+  it("defaults to true positive when LLM returns a non-OK HTTP status", async () => {
+    sinon.stub(globalThis, "fetch").resolves({ ok: false, status: 503 });
+    const group = makeGroup("u1", "u2");
+    const { truePositives } = await detector.classify([group], []);
+    expect(truePositives).to.have.length(1);
+  });
+
+  // ── caching: cache hit ───────────────────────────────────────────────────
+
+  it("uses cached verdict and does not call LLM when pair is clean", async () => {
+    const fetchStub = mockFetch("yes"); // should never be called
+    const group = makeGroup("u1", "u2", "A.java", "B.java");
+    const cachedVerdict = {
+      pairKey: detector.pairKey(group),
+      verdict: "no",
+      leftFilePath: "A.java",
+      rightFilePath: "B.java",
+      createdAt: Date.now(),
+    };
+    mockDb.getLLMVerdicts.resolves([cachedVerdict]);
+
+    const { truePositives, falsePositives } = await detector.classify([group], []);
+    expect(falsePositives).to.have.length(1); // cached "no"
+    expect(truePositives).to.have.length(0);
+    expect(fetchStub.called).to.equal(false);
+  });
+
+  it("persists new verdicts to the database", async () => {
+    mockFetch("yes");
+    const group = makeGroup("u1", "u2");
+    await detector.classify([group], []);
+    expect(mockDb.saveLLMVerdicts.calledOnce).to.equal(true);
+    const saved = mockDb.saveLLMVerdicts.firstCall.args[0];
+    expect(saved).to.have.length(1);
+    expect(saved[0].verdict).to.equal("yes");
+    expect(saved[0].pairKey).to.equal(detector.pairKey(group));
+  });
+
+  // ── caching: dirty-path invalidation ────────────────────────────────────
+
+  it("bypasses cache and calls LLM when a pair's left file is dirty", async () => {
+    const fetchStub = mockFetch("yes");
+    const group = makeGroup("u1", "u2", "Dirty.java", "Clean.java");
+    const cachedVerdict = {
+      pairKey: detector.pairKey(group),
+      verdict: "no",
+      leftFilePath: "Dirty.java",
+      rightFilePath: "Clean.java",
+      createdAt: Date.now(),
+    };
+    mockDb.getLLMVerdicts.resolves([cachedVerdict]);
+
+    const { truePositives } = await detector.classify([group], ["Dirty.java"]);
+    expect(fetchStub.calledOnce).to.equal(true); // cache bypassed
+    expect(truePositives).to.have.length(1);
+  });
+
+  it("bypasses cache and calls LLM when a pair's right file is dirty", async () => {
+    const fetchStub = mockFetch("no");
+    const group = makeGroup("u1", "u2", "Clean.java", "Dirty.java");
+    const cachedVerdict = {
+      pairKey: detector.pairKey(group),
+      verdict: "yes",
+      leftFilePath: "Clean.java",
+      rightFilePath: "Dirty.java",
+      createdAt: Date.now(),
+    };
+    mockDb.getLLMVerdicts.resolves([cachedVerdict]);
+
+    const { falsePositives } = await detector.classify([group], ["Dirty.java"]);
+    expect(fetchStub.calledOnce).to.equal(true); // cache bypassed
+    expect(falsePositives).to.have.length(1);
+  });
+
+  // ── concurrency batching ─────────────────────────────────────────────────
+
+  it("processes more than 20 candidates in batches without losing results", async () => {
+    // 25 groups; all uncached; LLM returns "yes" for even indices, "no" for odd
+    const fetchStub = sinon.stub(globalThis, "fetch");
+    for (let i = 0; i < 25; i++) {
+      const answer = i % 2 === 0 ? "yes" : "no";
+      fetchStub.onCall(i).resolves({ ok: true, json: async () => ({ message: { content: answer } }) });
+    }
+
+    const groups = Array.from({ length: 25 }, (_, i) =>
+      makeGroup(`l${i}`, `r${i}`, `File${i}A.java`, `File${i}B.java`)
+    );
+
+    const { truePositives, falsePositives } = await detector.classify(groups, []);
+    expect(truePositives.length + falsePositives.length).to.equal(25);
+    expect(truePositives).to.have.length(13); // indices 0,2,4,...,24
+    expect(falsePositives).to.have.length(12); // indices 1,3,5,...,23
+    expect(fetchStub.callCount).to.equal(25);
+  });
+
+  // ── prompt content ───────────────────────────────────────────────────────
+
+  it("includes both snippet IDs and code in the LLM prompt", async () => {
+    let capturedPrompt = "";
+    sinon.stub(globalThis, "fetch").callsFake(async (_url, opts) => {
+      const body = JSON.parse(opts.body);
+      capturedPrompt = body.messages[0].content;
+      return { ok: true, json: async () => ({ message: { content: "yes" } }) };
+    });
+
+    const group = makeGroup("unit-left-id", "unit-right-id");
+    await detector.classify([group], []);
+
+    expect(capturedPrompt).to.include("unit-left-id");
+    expect(capturedPrompt).to.include("unit-right-id");
+    expect(capturedPrompt).to.include("fn1");
+    expect(capturedPrompt).to.include("fn2");
+    expect(capturedPrompt).to.include("Answer:");
+  });
+
+  it("uses temperature 0 and num_predict 32 in the LLM request", async () => {
+    let capturedBody = null;
+    sinon.stub(globalThis, "fetch").callsFake(async (_url, opts) => {
+      capturedBody = JSON.parse(opts.body);
+      return { ok: true, json: async () => ({ message: { content: "yes" } }) };
+    });
+
+    await detector.classify([makeGroup("u1", "u2")], []);
+
+    expect(capturedBody.options.temperature).to.equal(0);
+    expect(capturedBody.options.num_predict).to.equal(32);
+    expect(capturedBody.stream).to.equal(false);
+  });
+
+  // ── pairKey stability ────────────────────────────────────────────────────
+
+  it("pairKey is order-independent (same key regardless of left/right swap)", () => {
+    const g1 = makeGroup("alpha", "beta");
+    const g2 = makeGroup("beta", "alpha");
+    expect(detector.pairKey(g1)).to.equal(detector.pairKey(g2));
+  });
+});

--- a/core/test/helpers/testConfig.mjs
+++ b/core/test/helpers/testConfig.mjs
@@ -17,6 +17,10 @@ export function buildTestConfig(overrides = {}) {
   return {
     ...DEFAULT_CONFIG,
     ...embeddingDefaults,
+    // Disable LLM filter by default in tests — it requires a live Ollama instance
+    // and would make every unit test hit the network. Tests that specifically test
+    // LLM filtering pass { enableLLMFilter: true } as an override.
+    enableLLMFilter: false,
     ...overrides,
   };
 }

--- a/core/test/resources/extractors/dryconfig.json
+++ b/core/test/resources/extractors/dryconfig.json
@@ -7,5 +7,6 @@
   "minBlockLines": 0,
   "threshold": 0.8,
   "embeddingSource": "http://localhost:11434",
-  "contextLength": 50
+  "contextLength": 50,
+  "enableLLMFilter": false
 }


### PR DESCRIPTION
Adds LLMFalsePositiveDetector that classifies embedding-confirmed duplicate candidates via the fine-tuned qwen-duplication-2b:latest model, separating true duplicates from false positives.

- New `llm_verdicts` SQLite table (LLMVerdictEntity) caches each pairKey → verdict so the LLM is skipped on clean pairs
- Dirty-path invalidation: stale verdicts are evicted fire-and-forget when files change; the detector always reclassifies dirty pairs
- Batched concurrency: max 20 parallel Ollama /api/chat requests per batch (Promise.all within each batch)
- Conservative fallback: HTTP errors or timeouts default to "yes" (keep as duplicate) to avoid silently dropping real duplication
- Opt-in via `enableLLMFilter` in dryconfig.json (default true)
- Existing BATS and unit tests set enableLLMFilter=false to avoid requiring a live Ollama instance; two new BATS tests verify cache speedup and dirty-file invalidation with LLM filter enabled